### PR TITLE
Pocket optimizations (includes multiple backends, jax etc.)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup
 
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 # there is some compiled code

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup
 
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 # there is some compiled code

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup
 
 
-__version__ = '0.0.1'
+__version__ = '0.1.0'
 
 
 # there is some compiled code

--- a/tests/bench_pocket.py
+++ b/tests/bench_pocket.py
@@ -1,0 +1,48 @@
+import sys
+import timeit
+from statistics import median, stdev
+
+import numpy as np
+from ztfsensors import test
+from ztfsensors.pocket import pocket_model_derivatives  # noqa
+
+model, pixels = test.get_pocket_test()
+test_column = np.full(pixels.shape[0], np.median(pixels))
+
+# %timeit pocket_model.apply(pixels.copy(), backend="numpy-nr");
+# %timeit pocket_model.apply(pixels.copy(), backend="numpy");
+# %timeit pocket_model.apply(pixels.copy(), backend="jax");
+# %timeit pocket_model.apply(pixels.copy(), backend="cpp");
+
+backends = ["numpy-nr", "numpy", "jax", "cpp"]
+number, repeat = 5, 5
+
+benchmarks = {
+    "apply": 'model.apply(pixels.copy(), backend="{}")',
+    "onecol": 'model.apply(pixels[1].copy(), backend="{}")',
+    "deriv": 'pocket_model_derivatives(model, test_column, backend="{}")',
+}
+
+if len(sys.argv) != 2:
+    sys.exit(f"usage: python {sys.argv[0]} [apply|onecol|deriv|all]")
+
+
+if sys.argv[1] == "all":
+    names = list(benchmarks.keys())
+else:
+    names = [sys.argv[1]]
+    assert names[0] in benchmarks.keys()
+
+for name in names:
+    code = benchmarks[name]
+    print(f"running benchmark {name}")
+    for backend in backends:
+        print(f"{backend:10s}: ", end="", flush=True)
+        res = timeit.repeat(
+            code.format(backend), globals=globals(), number=number, repeat=repeat
+        )
+        res = [x / number * 1000 for x in res]
+        if len(res) > 2:
+            res = res[1:]
+        print(f"{median(res[1:]):.1f}±{stdev(res):.1f}ms")
+    print()

--- a/ztfsensors/pocket.py
+++ b/ztfsensors/pocket.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+import logging
 import os
+import time
 
 import numpy as np
 import pandas

--- a/ztfsensors/pocket.py
+++ b/ztfsensors/pocket.py
@@ -1,28 +1,13 @@
 #!/usr/bin/env python3
 
-from importlib.resources import files
+import os
 
 import numpy as np
-
+import pandas
+import yaml
 from scipy import sparse
 from sksparse import cholmod
-
-#from ruamel.yaml import YAML
-
-import warnings
-import numpy
-
-try:
-    import jax
-    import jax.numpy as np
-    
-    _HAS_JAX = True
-except ImportError:
-    warnings.warn("jax is not installed. using numpy instead")
-    _HAS_JAX = False
-
-    
-import numpy as np
+from yaml.loader import SafeLoader
 
 from ._pocket import PocketModel as PocketModelCPP
 
@@ -40,10 +25,6 @@ def correct_pixels(model, pixels, hessian=None,
 #
 # config | may move in a config.py
 #
-import os
-import pandas
-import yaml
-from yaml.loader import SafeLoader
 
 _SOURCEDIR = os.path.dirname(os.path.realpath(__file__))
 CORRECTION_FILEPATH = os.path.join(_SOURCEDIR, "data", "pocket_corrections.yaml")
@@ -329,7 +310,6 @@ class PocketModel():
         """ """
         jacobian = self.get_jacobian(test_column)
 
-        import numpy as np # force numpy environment
         i, j = np.meshgrid(np.arange(jacobian.shape[0]),
                            np.arange(jacobian.shape[1]))
         i, j = i.flatten(), j.flatten() # flattend
@@ -405,15 +385,6 @@ class PocketModel():
             assert np.all(pocket >= 0.)
 
         return output
-
-
-    # ============= #
-    #  Properties   #
-    # ============= #
-    @property
-    def backend(self):
-        """ backend used for the apply() computation """
-        return self._backend
 
 
     

--- a/ztfsensors/pocket.py
+++ b/ztfsensors/pocket.py
@@ -1,98 +1,263 @@
 #!/usr/bin/env python3
 
-import time
-import logging
 from importlib.resources import files
 
 import numpy as np
-from pandas.core.arrays.period import delta_to_tick
-import pylab as pl
+
 from scipy import sparse
 from sksparse import cholmod
 
-from ruamel.yaml import YAML
+#from ruamel.yaml import YAML
 
-# this is the C++ version
-from ._pocket import _PocketModel
+import warnings
+try:
+    import jax
+    import jax.numpy as np
+    _HAS_JAX = True
+except ImportError:
+    warnings.warn("jax is not installed. using numpy instead")
+    _HAS_JAX = False
+    
+import numpy as np
 
 
+from ._pocket import PocketModel as PocketModelCPP
 
-class PocketModel:
-    """A pure numpy version of the pocket effect model
+# ============= #
+#  Internal Jax #
+# ============= #
+def _fill(pocket_q, pixel_q, cmax, nmax, alpha, beta):
+    """ pocket charge filling function
+
+    Parameters
+    ----------
+    pocket_q: float, Array
+        charge in the pocket prior read-out
+
+    pixel_q: float, Array
+        pixel charge prior read-out (undistorted)
+
+    cmax: float
+        pocket capacity
+
+    nmax: float
+        pixel capacity (not quite the full well)
+
+    alpha: float
+        from pocket transfer dynamics
+
+    beta: float
+        to-pocket transfer dynamics
+
+    Returns
+    -------
+    float, Array
+        charge entering the pocket.
     """
-    def __init__(self, alpha, cmax, beta, nmax):
-        """constructor - a set of
-        """
-        self.alpha = alpha
-        self.cmax = cmax
-        self.beta = beta
-        self.nmax = nmax
+    x = pocket_q / cmax
+    y = pixel_q / nmax
+    outval = cmax * (1 - x)**alpha * y**beta
+    #    return np.clip(outval,  0.,  pixel_q)
+    return outval
 
-    def _flush(self, q_j):
-        """electrons flushed from the pocket when reading
+def _flush(pocket_q, cmax, alpha):
+    """ pocket charge flushing function
+
+    Parameters
+    ----------
+    pocket_q: float, Array
+        charge in the pocket prior read-out
+
+    cmax: float
+        pocket capacity
+
+    alpha: float
+        from pocket transfer dynamics
+
+    Returns
+    -------
+    float, Array
+        charge leaving the pocket.
+    """
+    x = pocket_q / cmax
+    outval = cmax * x**alpha
+    #return np.clip(outval, 0, pocket_q)
+    return outval
+
+class PocketModel():
+    
+    def __init__(self, alpha, cmax, beta, nmax):
+        """ 
+        cmax: float
+            pocket capacity
+        
+        nmax: float
+            pixel capacity (not quite the full well)
+
+        alpha: float
+            from pocket transfer dynamics
+
+        beta: float
+            to-pocket transfer dynamics        
+
+        """
+        self._alpha = alpha
+        self._cmax = cmax
+        self._beta = beta
+        self._nmax = nmax
+        
+                
+    def flush(self, pocket_q):
+        """  transfer of electrons from the pocket to the pixels.
 
         Parameters
         ----------
-        q_i : array-like of floats
-          pocket content, j-th column
+        pocket_q: float, Array
+            charge in the pocket prior read-out
 
         Returns
         -------
-        number of electrons transfered from pocket : array-like of floats
+        float, Array
+            charge leaving the pocket.
         """
-        x = q_j / self.cmax
-        from_pocket = np.clip(self.cmax * np.power(x, self.alpha), 0., q_j)
-        return from_pocket
-
-    def _fill(self, q_j, n_j):
-        """electrons transfered from the pixel to the pocket
-
-        Parameters
-        ----------
-        q_j : array-like of floats
-          pocket contents j-th column
-        n_j : array-like of floats
-          pixel contents, j-th column
-
-        """
-        x = q_j / self.cmax
-        y = n_j / self.nmax
-        to_pocket = np.clip(self.cmax * np.power(1.-x, self.alpha) * np.power(y, self.beta),
-                            0.,  n_j)
-        return to_pocket
+        return _flush(pocket_q,
+                      self._cmax, self._alpha)
     
-    def apply(self, pix):
-        """apply the model to 2D image
+    def fill(self, pocket_q, pixel_q):
+        """ transfer of electrons entering the pocket
 
         Parameters
         ----------
-        pix : 2D array-like of floats
-          we assume that i labels the rows and j labels the physical columns.
+        pocket_q: float, Array
+            charge in the pocket prior read-out
 
-        .. note:: columns and rows are *not* interchangeable here !
+        pixel_q: float, Array
+            pixel charge prior read-out (undistorted)
+     
+        Returns
+        -------
+        float, Array
+            charge entering the pocket.
         """
-        nrows, ncols = pix.shape
+        return _fill(pocket_q, pixel_q,
+                     self._cmax, self._nmax, self._alpha, self._beta)
 
-        output = np.zeros_like(pix)
-        pocket = np.zeros(nrows)
+    def get_delta(self, pocket_q, pixel_q):
+        """ net pocket charge transfert 
 
-        for j in range(ncols):
-            n_j = pix[:,j]
-            from_pocket = self._flush(pocket)
-            to_pocket = self._fill(pocket, n_j)
-            delta = from_pocket - to_pocket
-            output[:,j] = n_j + delta
-            pocket -= delta
-            # just making sure that the pocket contents never become negative
-            #
-            # we may clip silently, but it is better for now to know that the
-            # correction is buggy and can throw the calculation into the ditch
-            assert np.all(pocket >= 0.)
+        Parameters
+        ----------
+        pocket_q: float, Array
+            charge in the pocket prior read-out
 
-        return output
+        pixel_q: float, Array
+            pixel charge prior read-out (undistorted)
+
+        Returns
+        -------
+        float, Array
+            pixel charge excess (>0) and deficit (<0) at the read-out.
+        """
+        from_pocket = self.flush(pocket_q)
+        to_pocket = self.fill(pocket_q, pixel_q)
+        delta = from_pocket - to_pocket
+        return delta
+
+    def get_pocket_and_corr(self, pocket_q, pixel_q):
+        """ scanning function providing corrected pixel and new pocket charge
+        
+        Parameters
+        ----------
+        pocket_q: float, Array
+            charge in the pocket prior read-out
+
+        pixel_q: float, Array
+            pixel charge prior read-out (undistorted)
+
+        Returns
+        -------
+        list
+            - new pocket charge: float, Array
+            - corrected pixel: float, Array
+        """
+        delta = self.get_delta(pocket_q, pixel_q)
+        pixel_corr = pixel_q + delta
+        new_pocket = pocket_q - delta
+        return new_pocket, pixel_corr
+        
+    def apply(self, pixels, init=None, backend="cpp"):
+        """ pocket effect correction 
+        
+        Parameters
+        ----------
+        pixels: 2d-Array
+            raw pixel map, including overhead of shape (M,N)
+
+        init: None, Array
+            initial condition of the pocket (M,). 
+            If None, zero is assumed.
+
+        backend: str
+            backend used for the computation
+
+        Returns
+        -------
+        2d-Array
+            pocket effect on pixel map (M,N)
+        """
+        if backend == "jax":
+            return self._scan_apply(pixels, init=init)
+        
+        elif backend == "numpy": 
+            return self._forloop_apply(pixels, init=init)
+        
+        elif backend == "cpp":
+            thiscpp = PocketModelCPP(self._alpha, self._cmax, self._beta, self._nmax)
+            return thiscpp.apply(pixels) # 0 is force here.
+            
+        else:
+            raise ValueError(f"unknown backend {backend}")
+        
+    def _scan_apply(self, pixels, init=None):
+        """ docstring, see: self.apply """
+        # with for lax.scan | jax
+        # atleast_2d and squeeze is to respect cpp-version behavior
+        
+        pixels = np.atleast_2d(pixels)
+        if init is None:
+            init = np.zeros(shape=pixels[:,0].shape)
+        
+        last_pocket, resbuff = jax.lax.scan(self.get_pocket_and_corr,
+                                                init,
+                                                pixels.T)
+        return resbuff.T.squeeze()
+    
+    def _forloop_apply(self, pixels, init=None):
+        """ docstring, see: self.apply """
+        # with for loop | numpy
+        pixels = np.atleast_2d(pixels)
+        if init is None:
+            pocket = np.zeros(shape=pixels[:,0].shape)
+        else:
+            pocket = init # for consistency between method
+
+        resbuff = []
+        for col in pixels.T:
+            pocket, corr = self.get_pocket_and_corr(pocket, col)
+            resbuff.append(corr) # build line by line
+            
+        return np.vstack(resbuff).T.squeeze()
+
+    # ============= #
+    #  Properties   #
+    # ============= #
+    @property
+    def backend(self):
+        """ backend used for the apply() computation """
+        return self._backend
 
 
-
+    
 def pocket_model_derivatives(model, pix, step=0.01):
     """model derivatives w.r.t the pixel values
 
@@ -113,13 +278,15 @@ def pocket_model_derivatives(model, pix, step=0.01):
     """
     N = len(pix)
     J = np.zeros((N, N))
-    v0 = model.apply(pix)
+    v0 = model.apply(pix, backend="cpp")
     for i in range(N):
         pix[i] += step
         vv = model.apply(pix)
         J[i] = (vv-v0)/step
         pix[i] -= step
     return J
+
+
 
 
 def correct_1d(model, pix, step=0.01, n_iter=5):
@@ -141,11 +308,14 @@ def correct_1d(model, pix, step=0.01, n_iter=5):
     ----------
     model : PocketModel
       the model used in the reconstruction
+
     pix : array_like
       the raw pixel array. The raw pixel array is expected to include the overscan.
       the overscan width (30 pixels) is currently hardcoded.
+
     step : float
       derivative step
+
     n_iter : int
       number of iterations
 
@@ -256,24 +426,22 @@ def correct_2d(model, pix, step=0.01, n_iter=4):
     return current_state, delta_tot, mask
 
 
-def get_model_parameter_file(filename=None):
-    """
-    """
-    if filename is None:
-        filename = 'pocket_corrections.yaml'
-    return files(__package__).joinpath('data', filename)
+# === config 
+import os
+import pandas
+import yaml
+from yaml.loader import SafeLoader
+
+_SOURCEDIR = os.path.dirname(os.path.realpath(__file__))
+CORRECTION_FILEPATH = os.path.join(_SOURCEDIR, "data", "pocket_corrections.yaml")
+
+# CONFIG
+with open(CORRECTION_FILEPATH) as f:
+    data = yaml.load(f, Loader=SafeLoader)
+    POCKET_PARAMETERS = pandas.DataFrame(data["data"]).set_index(["ccdid", "qid"])
 
 
-class PocketModelServer:
+def get_config(ccdid, qid):
+    """ returns the pocket effect parameter configuration for the given quadrant """
+    return POCKET_PARAMETERS.loc[ccdid, qid]
 
-    def __init__(self, filename=None):
-        """Constructor
-        """
-        path = get_model_parameter_file(filename)
-        yaml = YAML()
-        self.db = yaml.load(path)
-        self.data = self.db['data']
-
-    def __call__(self, ccdid, qid, mjd=None):
-        """
-        """

--- a/ztfsensors/pocket.py
+++ b/ztfsensors/pocket.py
@@ -41,7 +41,7 @@ class PocketModel:
         number of electrons transfered from pocket : array-like of floats
         """
         x = q_j / self.cmax
-        from_pocket = np.clip(self.cmax * np.pow(x, self.alpha), 0., q_j)
+        from_pocket = np.clip(self.cmax * np.power(x, self.alpha), 0., q_j)
         return from_pocket
 
     def _fill(self, q_j, n_j):
@@ -57,9 +57,10 @@ class PocketModel:
         """
         x = q_j / self.cmax
         y = n_j / self.nmax
-        to_pocket = np.clip(self.cmax * np.pow(1.-x, self.alpha) * np.pow(y, self.beta),
+        to_pocket = np.clip(self.cmax * np.power(1.-x, self.alpha) * np.power(y, self.beta),
                             0.,  n_j)
-
+        return to_pocket
+    
     def apply(self, pix):
         """apply the model to 2D image
 

--- a/ztfsensors/pocket.py
+++ b/ztfsensors/pocket.py
@@ -16,7 +16,7 @@ from ._pocket import PocketModel as PocketModelCPP
 
 __all__ = ["PocketModel", "correct_pixels"]
 
-DEFAULT_BACKEND = "numpy"
+DEFAULT_BACKEND = "numpy-nr"
 
 
 def correct_pixels(model, pixels, hessian=None,

--- a/ztfsensors/test.py
+++ b/ztfsensors/test.py
@@ -1,0 +1,36 @@
+
+def get_pocket_test(filename = "ztf_20200401152477_000517_zg_c06_o.fits.fz"):
+    """ get the pocket model and a raw-data_and_overscan test case.
+    
+    Returns
+    -------
+    PocketModel, 2d-array
+        - pockelmodel
+        - pixel
+
+    Example
+    -------
+    pocket_model, pixels = get_pocket_test()
+    %time _ = pocket_model.apply(pixels, backend="numpy")
+
+    """
+    import ztfimg
+    import numpy as np
+    from ztfsensors import pocket
+    
+    
+    # Access the raw quadrant    
+    rawimg = ztfimg.RawCCD.from_filename(filename, as_path=False) # providing the exact path
+    quad = rawimg.get_quadrant(1)
+    
+    # Get data with overscan at the end
+    data_and_overscan = quad.get_data_and_overscan()
+    
+    # the model with quadrant's pocket parameter
+    pocket_model = pocket.PocketModel(**pocket.get_config(quad.ccdid, quad.qid).values[0])
+    
+    current_state = data_and_overscan.copy()
+    current_state[:,-30:] = 0. # set overscan to zero
+    current_state[0:2] = np.median(data_and_overscan) # default
+    
+    return pocket_model, current_state

--- a/ztfsensors/test.py
+++ b/ztfsensors/test.py
@@ -1,5 +1,5 @@
 
-def get_pocket_test(filename = "ztf_20200401152477_000517_zg_c06_o.fits.fz"):
+def get_pocket_test(filename = "ztf_20200401152477_000517_zg_c06_o.fits.fz", data=False):
     """ get the pocket model and a raw-data_and_overscan test case.
     
     Returns
@@ -28,6 +28,8 @@ def get_pocket_test(filename = "ztf_20200401152477_000517_zg_c06_o.fits.fz"):
     
     # the model with quadrant's pocket parameter
     pocket_model = pocket.PocketModel(**pocket.get_config(quad.ccdid, quad.qid).values[0])
+    if data:
+        return pocket_model, data_and_overscan
     
     current_state = data_and_overscan.copy()
     current_state[:,-30:] = 0. # set overscan to zero


### PR DESCRIPTION
Based on @MickaelRigault's https://github.com/nregnault/ztfsensors/tree/jaxnumpycpp branch.

- optimize `pocket_model_derivatives` + numpy-nr backend
- switch to numpy-nr backend by default (fastest backend currently)
- add benchmark script