### PR TITLE
make the cpp import optional

### DIFF
--- a/ztfsensors/__init__.py
+++ b/ztfsensors/__init__.py
@@ -1,2 +1,1 @@
 from .pocket import PocketModel
-from ._pocket import _PocketModel

--- a/ztfsensors/pocket.py
+++ b/ztfsensors/pocket.py
@@ -12,7 +12,6 @@ from scipy import sparse
 
 from yaml.loader import SafeLoader
 
-from ._pocket import _PocketModel as PocketModelCPP
 
 
 __all__ = ["PocketModel", "correct_pixels"]
@@ -153,6 +152,7 @@ class PocketModel():
         """
         # special case, computation not from python
         if backend == "cpp":
+            from ._pocket import _PocketModel as PocketModelCPP
             thiscpp = PocketModelCPP(self._alpha, self._cmax, self._beta, self._nmax)
             return thiscpp.apply(pixels) # 0 is force here.
 

--- a/ztfsensors/pocket.py
+++ b/ztfsensors/pocket.py
@@ -13,8 +13,7 @@ from scipy import sparse
 from yaml.loader import SafeLoader
 
 
-
-__all__ = ["PocketModel", "correct_pixels"]
+__all__ = ["PocketModel"]
 
 DEFAULT_BACKEND = "numpy-nr"
 


### PR DESCRIPTION
This is a workaround to solve some env issues on CentOS7 (the jupyter platform). Our current env (zenv11) is not in a good shape and conda won't allow installing a c++ compiler that supports c11. Since we don't use the cpp backend by default this is just a quick workaround for now. Once the jupyter platform migrates to rh9 we can create a new env and use a more recent compiler. cc @MickaelRigault 