### PR TITLE
Compare backends and fix small inconsistencies

### DIFF
--- a/tests/bench_pocket.py
+++ b/tests/bench_pocket.py
@@ -14,7 +14,7 @@ test_column = np.full(pixels.shape[0], np.median(pixels))
 # %timeit pocket_model.apply(pixels.copy(), backend="jax");
 # %timeit pocket_model.apply(pixels.copy(), backend="cpp");
 
-backends = ["numpy-nr", "numpy", "jax", "cpp"]
+backends = ["numpy-nr", "numpy", "cpp"]  # "jax",
 number, repeat = 5, 5
 
 benchmarks = {

--- a/tests/test_1d_pocket_corr.py
+++ b/tests/test_1d_pocket_corr.py
@@ -1,6 +1,4 @@
 
-import numpy as np
-import pylab as pl
 from ztfsensors import sims, PocketModel
 from ztfsensors import pocket
 
@@ -27,5 +25,3 @@ def test_1d_pocket_corr(size=250, noise=True):
     # fig = pl.gcf()
     # fig.axes[0].plot(cs, 'g.:')
     # fig.axes[1].plot(delta, 'g.:')
-
-    

--- a/tests/test_2d_pocket_corr.py
+++ b/tests/test_2d_pocket_corr.py
@@ -1,5 +1,4 @@
 
-import numpy as np
 import pylab as pl
 from ztfsensors import sims, PocketModel
 from ztfsensors import pocket
@@ -29,7 +28,5 @@ def test_2d_pocket_corr(shape=(1000,1000), skylev=322.):
     axes[1].set_xlabel('x [pixels]')
     axes[1].set_title('correction')
     fig.suptitle('2D correction')
-
-    print(cs)
 
     return cs, delta

--- a/tests/test_pocket.py
+++ b/tests/test_pocket.py
@@ -2,23 +2,10 @@ import numpy as np
 import pytest
 
 from ztfsensors.pocket import PocketModel
-from ztfsensors.sims import GaussianPSF1D, Line
+from ztfsensors.test import POCKET_PARAMS, simulate_1d, simulate_2d
 
 BACKENDS = ["numpy-nr", "numpy", "cpp"]
-POCKET_PARAMS = (1.74, 3056.0, 0.39, 250000.0)
 # data_and_overscan = correct_pixels(model, data)
-
-
-def simulate_1d(n_stars=5, size=250, skylev=200.0, noise=False):
-    np.random.seed(42)
-    pocket_model = PocketModel(*POCKET_PARAMS)
-    psf = GaussianPSF1D()
-    line = Line(size=size, skylev=skylev)
-    line.add_stars(line.gen_stars(n_stars), psf)
-    if noise:
-        line.add_noise()
-    line.distort(pocket_model)
-    return line.distorted_data
 
 
 @pytest.mark.parametrize("size", [100, 350, 1000])
@@ -33,3 +20,21 @@ def test_apply_all_backends_1d(size, skylev, noise):
     ref = BACKENDS[0]
     for name in BACKENDS[1:]:
         np.testing.assert_array_almost_equal(res[ref], res[name], decimal=11)
+
+
+@pytest.mark.parametrize("shape", [(200, 200), (1000, 1000)])
+@pytest.mark.parametrize("skylev", [100, 200, 1000])
+@pytest.mark.parametrize("noise", [False, True])
+def test_apply_all_backends_2d(shape, skylev, noise):
+    data = simulate_2d(shape=shape, skylev=skylev, noise=noise)
+    model = PocketModel(*POCKET_PARAMS)
+    res = {name: model.apply(data.copy(), backend=name) for name in BACKENDS}
+
+    # test that all methods give the same result
+    # note: we exclude the first 50 columns because there are some differences
+    # with the cpp version for the first columns...
+    ref = BACKENDS[0]
+    for name in BACKENDS[1:]:
+        np.testing.assert_array_almost_equal(
+            res[ref][:, 50:], res[name][:, 50:], decimal=8
+        )

--- a/tests/test_pocket.py
+++ b/tests/test_pocket.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from ztfsensors.pocket import PocketModel
+from ztfsensors.sims import GaussianPSF1D, Line
+
+BACKENDS = ["numpy-nr", "numpy", "cpp"]
+POCKET_PARAMS = (1.74, 3056.0, 0.39, 250000.0)
+# data_and_overscan = correct_pixels(model, data)
+
+
+def simulate_1d(n_stars=5, size=250, skylev=200.0, noise=False):
+    np.random.seed(42)
+    pocket_model = PocketModel(*POCKET_PARAMS)
+    psf = GaussianPSF1D()
+    line = Line(size=size, skylev=skylev)
+    line.add_stars(line.gen_stars(n_stars), psf)
+    if noise:
+        line.add_noise()
+    line.distort(pocket_model)
+    return line.distorted_data
+
+
+@pytest.mark.parametrize("size", [100, 350, 1000])
+@pytest.mark.parametrize("skylev", [100, 200, 1000])
+@pytest.mark.parametrize("noise", [False, True])
+def test_apply_all_backends_1d(size, skylev, noise):
+    data = simulate_1d(n_stars=5, size=size, skylev=skylev, noise=noise)
+    model = PocketModel(*POCKET_PARAMS)
+    res = {name: model.apply(data.copy(), backend=name) for name in BACKENDS}
+
+    # test that all methods give the same result
+    ref = BACKENDS[0]
+    for name in BACKENDS[1:]:
+        np.testing.assert_array_almost_equal(res[ref], res[name], decimal=11)

--- a/tests/test_pocket.py
+++ b/tests/test_pocket.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pytest
 
+from ztfsensors.correct import correct_pixels
 from ztfsensors.pocket import PocketModel
-from ztfsensors.test import POCKET_PARAMS, simulate_1d, simulate_2d
+from ztfsensors.test import POCKET_PARAMS, get_pocket_test, simulate_1d, simulate_2d
 
 BACKENDS = ["numpy-nr", "numpy", "cpp"]
 # data_and_overscan = correct_pixels(model, data)
@@ -37,4 +38,18 @@ def test_apply_all_backends_2d(shape, skylev, noise):
     for name in BACKENDS[1:]:
         np.testing.assert_array_almost_equal(
             res[ref][:, 50:], res[name][:, 50:], decimal=8
+        )
+
+
+def test_image():
+    model, data = get_pocket_test()
+    res = {name: correct_pixels(model, data.copy(), backend=name) for name in BACKENDS}
+
+    # test that all methods give the same result
+    # note: we exclude the first 10 columns because there are some differences
+    # with the cpp version for the first columns...
+    ref = BACKENDS[0]
+    for name in BACKENDS[1:]:
+        np.testing.assert_array_almost_equal(
+            res[ref][:, 10:], res[name][:, 10:], decimal=2
         )

--- a/tests/test_pocket.py
+++ b/tests/test_pocket.py
@@ -53,3 +53,20 @@ def test_image():
         np.testing.assert_array_almost_equal(
             res[ref][:, 10:], res[name][:, 10:], decimal=2
         )
+
+
+def test_image_nans():
+    model, data = get_pocket_test("ztf_20180911343345_000600_zr_c15_o.fits.fz")
+    res = {name: correct_pixels(model, data.copy(), backend=name) for name in BACKENDS}
+
+    for name in BACKENDS:
+        assert np.isnan(res["numpy-nr"]).sum() == 0
+
+    # test that all methods give the same result
+    # note: we exclude the first 10 columns because there are some differences
+    # with the cpp version for the first columns...
+    ref = BACKENDS[0]
+    for name in BACKENDS[1:]:
+        np.testing.assert_array_almost_equal(
+            res[ref][:, 10:], res[name][:, 10:], decimal=2
+        )

--- a/ztfsensors/_pocket.cpp
+++ b/ztfsensors/_pocket.cpp
@@ -36,7 +36,11 @@ public:
               return 0.;
           }
       double x = q_i / _cmax;
-      return _cmax * pow(x, _alpha);
+      double from_pocket = _cmax * pow(x, _alpha);
+      if (from_pocket>q_i)
+          return q_i;
+      else
+          return from_pocket;
     }
 
     // transfer of electrons from the pixel to the pocket.
@@ -52,9 +56,9 @@ public:
             return 0.;
         double to_pocket = _cmax * pow(1.-x, _alpha) * pow(y, _beta);
         if (to_pocket>n_i)
-          return n_i;
+            return n_i;
         else
-          return to_pocket;
+            return to_pocket;
     }
 
     // apply the model to a line

--- a/ztfsensors/_pocket.cpp
+++ b/ztfsensors/_pocket.cpp
@@ -50,7 +50,11 @@ public:
         double y = n_i / _nmax;
         if(y<0.)
             return 0.;
-        return _cmax * pow(1.-x, _alpha) * pow(y, _beta);
+        double to_pocket = _cmax * pow(1.-x, _alpha) * pow(y, _beta);
+        if (to_pocket>n_i)
+          return n_i;
+        else
+          return to_pocket;
     }
 
     // apply the model to a line

--- a/ztfsensors/pocket.py
+++ b/ztfsensors/pocket.py
@@ -219,7 +219,7 @@ class PocketModel():
             pocket, corr = self.get_pocket_and_corr(pocket, col)
             resbuff.append(corr) # build line by line
 
-        return np.vstack(resbuff).T.squeeze()
+        return np.vstack(resbuff).T
 
     def _forloop_apply_baseline(self, pix, init):
         """apply the model to 2D image
@@ -250,17 +250,17 @@ class PocketModel():
             # c_max * (pocket / c_max)**alpha
             tmp = pocket * cmax_inv
             from_pocket = tmp**self._alpha
+            from_pocket *= self._cmax
             np.clip(from_pocket, 0, pocket, out=from_pocket)
 
             # to_pocket = self.fill(pocket, n_j):
             # cmax * (1 - pocket / cmax)**alpha * (pixel / nmax)**beta
             to_pocket = 1 - tmp
             np.power(to_pocket, self._alpha, out=to_pocket)
-            to_pocket *= pix_beta[j]
+            to_pocket *= pix_beta[j] * self._cmax
             np.clip(to_pocket,  0.,  pix[j], out=to_pocket)
 
             delta = from_pocket - to_pocket
-            delta *= self._cmax
 
             pix[j] += delta
             pocket -= delta

--- a/ztfsensors/pocket.py
+++ b/ztfsensors/pocket.py
@@ -8,10 +8,8 @@ import numpy as np
 import pandas
 import yaml
 from scipy import sparse
-
-
+from sksparse import cholmod
 from yaml.loader import SafeLoader
-
 
 __all__ = ["PocketModel"]
 

--- a/ztfsensors/test.py
+++ b/ztfsensors/test.py
@@ -1,7 +1,16 @@
+import numpy as np
+import ztfimg
 
-def get_pocket_test(filename = "ztf_20200401152477_000517_zg_c06_o.fits.fz", data=False):
-    """ get the pocket model and a raw-data_and_overscan test case.
-    
+from ztfsensors import pocket
+from ztfsensors.sims import GaussianPSF1D, GaussianPSF2D, Image, Line
+from ztfsensors.pocket import PocketModel
+
+POCKET_PARAMS = (1.74, 3056.0, 0.39, 250000.0)
+
+
+def get_pocket_test(filename="ztf_20200401152477_000517_zg_c06_o.fits.fz", data=False):
+    """get the pocket model and a raw-data_and_overscan test case.
+
     Returns
     -------
     PocketModel, 2d-array
@@ -14,25 +23,47 @@ def get_pocket_test(filename = "ztf_20200401152477_000517_zg_c06_o.fits.fz", dat
     %time _ = pocket_model.apply(pixels, backend="numpy")
 
     """
-    import ztfimg
-    import numpy as np
-    from ztfsensors import pocket
-    
-    
-    # Access the raw quadrant    
-    rawimg = ztfimg.RawCCD.from_filename(filename, as_path=False) # providing the exact path
+
+    # Access the raw quadrant
+    rawimg = ztfimg.RawCCD.from_filename(filename, as_path=False)
     quad = rawimg.get_quadrant(1)
-    
+
     # Get data with overscan at the end
     data_and_overscan = quad.get_data_and_overscan()
-    
+
     # the model with quadrant's pocket parameter
-    pocket_model = pocket.PocketModel(**pocket.get_config(quad.ccdid, quad.qid).values[0])
+    pocket_model = pocket.PocketModel(
+        **pocket.get_config(quad.ccdid, quad.qid).values[0]
+    )
     if data:
         return pocket_model, data_and_overscan
-    
+
     current_state = data_and_overscan.copy()
-    current_state[:,-30:] = 0. # set overscan to zero
-    current_state[0:2] = np.median(data_and_overscan) # default
-    
+    current_state[:, -30:] = 0.0  # set overscan to zero
+    current_state[0:2] = np.median(data_and_overscan)  # default
+
     return pocket_model, current_state
+
+
+def simulate_1d(n_stars=5, size=250, skylev=200.0, noise=False):
+    np.random.seed(42)
+    pocket_model = PocketModel(*POCKET_PARAMS)
+    psf = GaussianPSF1D()
+    line = Line(size=size, skylev=skylev)
+    line.add_stars(line.gen_stars(n_stars), psf)
+    if noise:
+        line.add_noise()
+    line.distort(pocket_model)
+    return line.distorted_data
+
+
+def simulate_2d(n_stars=250, shape=(1000, 1000), skylev=200.0, noise=False):
+    np.random.seed(42)
+    pocket_model = PocketModel(*POCKET_PARAMS)
+    psf = GaussianPSF2D()
+    im = Image(shape=shape, skylev=skylev)
+    im.add_stars(im.gen_stars(n_stars), psf)
+    if noise:
+        im.add_noise()
+    im.distort(pocket_model)
+    return im.distorted_data


### PR DESCRIPTION
- add new tests comparing the different backends (except jax which seems broken currently)
- the cpp backend was missing some clipping (e.g. to avoid filling the pockets with more than what the pixel contains), this removed the main differences with the other backends but there are still some small differences in the first columns

cc @MickaelRigault @nregnault 