### PR TITLE
Numpy eqfunc

### DIFF
--- a/tests/pocket/test_base.py
+++ b/tests/pocket/test_base.py
@@ -467,18 +467,32 @@ class TestTabulation:
         with pytest.raises(ValueError, match="xmin.*xmax"):
             dummy_model.default_tabulation_grid(n=10, xmin=100.0, xmax=10.0)
 
-    def test_make_eq_func(self, dummy_model):
-        """Test make_eq_func creates a JaxEqFunc."""
+    def test_make_eq_func_default_returns_numpy(self, dummy_model):
+        """Test make_eq_func default (no backend) creates a NumpyEqFunc."""
+        from ztfsensors.pocket.models.base import NumpyEqFunc
+
         params = np.array([0.5, 10.0])
         ccd_temp = 160.0
 
         eq_func = dummy_model.make_eq_func(params, ccd_temp)
 
+        assert isinstance(eq_func, NumpyEqFunc)
+        assert eq_func.x_grid.shape[0] == 100  # default n=100
+
+    def test_make_eq_func_jax_backend_returns_jax(self, dummy_model):
+        """Test make_eq_func with backend='jax' creates a JaxEqFunc."""
+        params = np.array([0.5, 10.0])
+        ccd_temp = 160.0
+
+        eq_func = dummy_model.make_eq_func(params, ccd_temp, backend="jax")
+
         assert isinstance(eq_func, JaxEqFunc)
         assert eq_func.x_grid.shape[0] == 100  # default n=100
 
     def test_make_eq_func_custom_grid(self, dummy_model):
-        """Test make_eq_func with custom tabulation grid."""
+        """Test make_eq_func with custom tabulation grid (numpy backend)."""
+        from ztfsensors.pocket.models.base import NumpyEqFunc
+
         params = np.array([0.5, 10.0])
         ccd_temp = 160.0
         custom_grid = np.linspace(0, 100, 50)
@@ -487,9 +501,10 @@ class TestTabulation:
             params, ccd_temp, tabulation_grid=custom_grid
         )
 
+        assert isinstance(eq_func, NumpyEqFunc)
         assert eq_func.x_grid.shape[0] == 50
-        assert jnp.isclose(eq_func.x_grid[0], 0.0)
-        assert jnp.isclose(eq_func.x_grid[-1], 100.0)
+        assert np.isclose(eq_func.x_grid[0], 0.0)
+        assert np.isclose(eq_func.x_grid[-1], 100.0)
 
     def test_make_eq_func_evaluates_correctly(self, dummy_model):
         """Test that created eq_func evaluates correctly."""

--- a/tests/pocket/test_db.py
+++ b/tests/pocket/test_db.py
@@ -441,13 +441,16 @@ class TestGetEqFunc:
     """Test the get_eq_func method."""
 
     def test_get_eq_func_returns_jax_func(self, sample_poly_db):
-        """Test that get_eq_func returns JaxEqFunc."""
-        # Use a simple grid to avoid dimension issues
+        """Test that get_eq_func with backend='jax' returns JaxEqFunc."""
         grid = np.array([50.0, 100.0, 500.0, 1000.0])
         eq_func = sample_poly_db.get_eq_func(
-            ccdid=1, qid=1, mjd=58050.0, ccd_temp=160.0, tabulation_grid=grid
+            ccdid=1,
+            qid=1,
+            mjd=58050.0,
+            ccd_temp=160.0,
+            tabulation_grid=grid,
+            backend="jax",
         )
-
         assert isinstance(eq_func, JaxEqFunc)
 
     def test_get_eq_func_evaluates(self, sample_poly_db):
@@ -483,12 +486,25 @@ class TestGetEqFunc:
     def test_get_eq_func_custom_grid(self, sample_poly_db):
         """Test get_eq_func with custom tabulation grid."""
         custom_grid = np.array([50.0, 100.0, 500.0, 1000.0])
-
         eq_func = sample_poly_db.get_eq_func(
-            ccdid=1, qid=1, mjd=58050.0, ccd_temp=160.0, tabulation_grid=custom_grid
+            ccdid=1,
+            qid=1,
+            mjd=58050.0,
+            ccd_temp=160.0,
+            tabulation_grid=custom_grid,
+            backend="jax",
         )
-
         assert isinstance(eq_func, JaxEqFunc)
+
+    def test_get_eq_func_default_returns_numpy_func(self, sample_poly_db):
+        """Test that get_eq_func default (no backend arg) returns NumpyEqFunc."""
+        from ztfsensors.pocket.models.base import NumpyEqFunc
+
+        grid = np.array([50.0, 100.0, 500.0, 1000.0])
+        eq_func = sample_poly_db.get_eq_func(
+            ccdid=1, qid=1, mjd=58050.0, ccd_temp=160.0, tabulation_grid=grid
+        )
+        assert isinstance(eq_func, NumpyEqFunc)
 
     def test_get_eq_func_no_match(self, sample_poly_db):
         """Test that get_eq_func raises error for non-existent entry."""

--- a/tests/pocket/test_pix_distortion.py
+++ b/tests/pocket/test_pix_distortion.py
@@ -1,0 +1,585 @@
+"""
+Tests for pix_distortion.py: invert_line, invert (JAX) and their
+numpy equivalents (NumpyEqFunc, invert_numpy).
+
+Structure
+---------
+Part 1 – JAX backend invariants (pass immediately with the current code):
+  - TestInvertLine        : mathematical invariants of the JAX scan-based invert_line
+  - TestInvert            : 2-D wrapper (vmap) — invariants and consistency with invert_line
+
+Part 2 – numpy backend (fail until NumpyEqFunc / invert_numpy are implemented):
+  - TestNumpyEqFunc       : NumpyEqFunc behaves like JaxEqFunc (clipping, interp, 2-D input)
+  - TestInvertNumpy       : invert_numpy behaviour and exact agreement with JAX invert
+  - TestCorrectPixels     : correct_pixels dispatches on f_eq type
+  - TestMakeEqFuncBackend : BaseEquilibriumModel.make_eq_func(backend=...) kwarg
+  - TestDbGetEqFuncBackend: EqFuncDb.get_eq_func(backend=...) kwarg
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from ztfsensors.pocket.models.base import JaxEqFunc
+from ztfsensors.pocket.pix_distortion import distort_line, invert, invert_line, predict
+
+# ============================================================================
+# Shared fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def linear_eq_func():
+    """f_eq(x) = 0.01 * x  (linear, easy to reason about analytically).
+
+    x_grid starts at 0 so that f_eq(0) = 0 — useful for the zero-input tests.
+    """
+    alpha = 0.01
+    x_grid = jnp.linspace(0.0, 5000.0, 1000, dtype=jnp.float32)
+    y_grid = (alpha * x_grid).astype(jnp.float32)
+    return JaxEqFunc(x_grid=x_grid, y_grid=y_grid)
+
+
+@pytest.fixture
+def realistic_eq_func():
+    """A log-saturating equilibrium function, similar to real ZTF curves.
+
+    x_grid starts at 10 (matches typical sky level lower bound).
+    """
+    x_grid = jnp.geomspace(10.0, 5000.0, 500, dtype=jnp.float32)
+    y_grid = jnp.array(30.0 * jnp.log1p(x_grid / 50.0), dtype=jnp.float32)
+    return JaxEqFunc(x_grid=x_grid, y_grid=y_grid)
+
+
+@pytest.fixture
+def flat_row():
+    """A 1-D pixel row: constant sky level (200 ADU) + small Gaussian noise."""
+    rng = np.random.default_rng(0)
+    return (300.0 + rng.normal(0.0, 2.0, 200)).astype(np.float32)
+
+
+@pytest.fixture
+def realistic_image():
+    """A 2-D image (30 rows × 200 cols) with sky background and two bright stars."""
+    rng = np.random.default_rng(1)
+    img = np.full((30, 200), 200.0, dtype=np.float32)
+    img += rng.normal(0.0, 3.0, img.shape).astype(np.float32)
+    img[5, 40:46] += 800.0  # bright star
+    img[15, 120:124] += 400.0  # dimmer star
+    return img
+
+
+# ============================================================================
+# Part 1 — JAX backend: mathematical invariants
+# ============================================================================
+
+
+class TestInvertLine:
+    """Mathematical invariants of invert_line (JAX lax.scan-based)."""
+
+    def test_output_shape(self, realistic_eq_func, flat_row):
+        """Output has the same shape as the input row."""
+        d = jnp.array(flat_row)
+        result = invert_line(d, realistic_eq_func)
+        assert result.shape == d.shape
+
+    def test_zero_row_gives_zero_output(self, linear_eq_func):
+        """All-zero input → all-zero output.
+
+        With linear_eq_func: f_eq(0) = 0.
+        → delta[0] = f_eq(0) - 0 = 0
+        → delta[i] = f_eq(0) - f_eq(0) = 0 for all i
+        → output = input + 0 = 0
+        """
+        d = jnp.zeros(50, dtype=jnp.float32)
+        result = invert_line(d, linear_eq_func)
+        np.testing.assert_allclose(np.array(result), 0.0, atol=1e-6)
+
+    def test_constant_row_first_pixel_corrected(self, linear_eq_func):
+        """For constant input d = v, result[0] = v + f_eq(v).
+
+        The pocket hasn't charged at all before the first pixel, so the
+        first delta equals f_eq(v) entirely.
+        """
+        alpha, v = 0.01, 500.0
+        d = jnp.full(50, v, dtype=jnp.float32)
+        result = invert_line(d, linear_eq_func)
+        expected_first = v + alpha * v  # v + f_eq(v)
+        np.testing.assert_allclose(float(result[0]), expected_first, rtol=1e-4)
+
+    def test_constant_row_remaining_pixels_unchanged(self, linear_eq_func):
+        """For constant input d = v, result[i > 0] = v.
+
+        When the signal is constant the pocket is at equilibrium after the
+        first pixel, so delta[i > 0] = f_eq(v) - f_eq(v) = 0.
+        """
+        v = 500.0
+        d = jnp.full(50, v, dtype=jnp.float32)
+        result = invert_line(d, linear_eq_func)
+        np.testing.assert_allclose(np.array(result[1:]), v, rtol=1e-4)
+
+    def test_delta_equals_diff_of_feq(self, linear_eq_func):
+        """Verify the closed-form: correction[i] = f_eq(d[i]) - f_eq(d[i-1]).
+
+        This is the key identity that allows the scan to be replaced by a
+        vectorised numpy diff (used in invert_numpy).
+
+        We use a step-function input so the identity is verifiable with
+        scalar f_eq calls (matching exactly what lax.scan does):
+
+            d = [v, v, v, w, w, w]
+            corrections = [f_eq(v), 0, 0, f_eq(w)-f_eq(v), 0, 0]
+        """
+        v, w = 200.0, 800.0
+        d = jnp.array([v, v, v, w, w, w], dtype=jnp.float32)
+
+        result = invert_line(d, linear_eq_func)
+        corrections = np.array(result - d)
+
+        feq_v = float(linear_eq_func(jnp.array(v, dtype=jnp.float32)))
+        feq_w = float(linear_eq_func(jnp.array(w, dtype=jnp.float32)))
+        expected = np.array(
+            [feq_v, 0.0, 0.0, feq_w - feq_v, 0.0, 0.0], dtype=np.float32
+        )
+        np.testing.assert_allclose(corrections, expected, atol=1e-5)
+
+    def test_roundtrip_with_distort_line(self, realistic_eq_func):
+        """invert_line(distort_line(x, f_eq), f_eq) ≈ x."""
+        rng = np.random.default_rng(7)
+        true_vals = jnp.array(200.0 + rng.normal(0, 20, 100).astype(np.float32))
+        distorted = distort_line(true_vals, realistic_eq_func)
+        recovered = invert_line(distorted, realistic_eq_func)
+        np.testing.assert_allclose(np.array(recovered), np.array(true_vals), atol=0.5)
+
+    def test_total_correction_equals_last_feq(self, realistic_eq_func, flat_row):
+        """Sum of corrections over a row = f_eq(last pixel).
+
+        The corrections are diffs of feq values (telescoping sum):
+          delta[0] + ... + delta[n-1]
+          = feq(d[0]) + (feq(d[1])-feq(d[0])) + ... + (feq(d[n-1])-feq(d[n-2]))
+          = feq(d[n-1])
+
+        Note: individual corrections CAN be negative when a pixel is fainter
+        than its predecessor (the pocket discharges, adding charge back).
+        """
+        d = jnp.array(flat_row)
+        result = invert_line(d, realistic_eq_func)
+        total_correction = float(jnp.sum(result - d))
+        expected = float(realistic_eq_func(d[-1]))
+        np.testing.assert_allclose(total_correction, expected, rtol=1e-4)
+
+
+class TestInvert:
+    """Mathematical invariants of invert (JAX vmap over rows, 2-D)."""
+
+    def test_output_shape(self, realistic_eq_func, realistic_image):
+        """Output has the same shape as the input image."""
+        d = jnp.array(realistic_image)
+        result = invert(d, realistic_eq_func)
+        assert result.shape == d.shape
+
+    def test_zero_image_gives_zero_output(self, linear_eq_func):
+        """All-zero image → all-zero output (f_eq(0) = 0 for linear_eq_func)."""
+        d = jnp.zeros((10, 100), dtype=jnp.float32)
+        result = invert(d, linear_eq_func)
+        np.testing.assert_allclose(np.array(result), 0.0, atol=1e-6)
+
+    def test_each_row_matches_invert_line(self, realistic_eq_func, realistic_image):
+        """invert(image)[i] must equal invert_line(image[i]) for every row i."""
+        d = jnp.array(realistic_image)
+        result_2d = invert(d, realistic_eq_func)
+        for i in range(realistic_image.shape[0]):
+            result_1d = invert_line(d[i], realistic_eq_func)
+            np.testing.assert_allclose(
+                np.array(result_2d[i]),
+                np.array(result_1d),
+                atol=1e-5,
+                err_msg=f"Row {i} mismatch between invert and invert_line",
+            )
+
+    def test_roundtrip_with_predict(self, realistic_eq_func, realistic_image):
+        """invert(predict(image, f_eq), f_eq) ≈ image."""
+        true_vals = jnp.array(realistic_image)
+        distorted = predict(true_vals, realistic_eq_func)
+        recovered = invert(distorted, realistic_eq_func)
+        np.testing.assert_allclose(np.array(recovered), np.array(true_vals), atol=0.5)
+
+
+# ============================================================================
+# Part 2 — numpy backend (will fail until NumpyEqFunc / invert_numpy exist)
+# ============================================================================
+
+
+class TestNumpyEqFunc:
+    """NumpyEqFunc must behave identically to JaxEqFunc on any input shape."""
+
+    @pytest.fixture
+    def numpy_linear_eq_func(self, linear_eq_func):
+        from ztfsensors.pocket.models.base import NumpyEqFunc
+
+        return NumpyEqFunc(
+            x_grid=np.array(linear_eq_func.x_grid),
+            y_grid=np.array(linear_eq_func.y_grid),
+        )
+
+    @pytest.fixture
+    def numpy_realistic_eq_func(self, realistic_eq_func):
+        from ztfsensors.pocket.models.base import NumpyEqFunc
+
+        return NumpyEqFunc(
+            x_grid=np.array(realistic_eq_func.x_grid),
+            y_grid=np.array(realistic_eq_func.y_grid),
+        )
+
+    def test_returns_numpy_array(self, numpy_linear_eq_func):
+        """__call__ must return a plain numpy array, not a JAX array."""
+        x = np.array([100.0, 200.0, 300.0], dtype=np.float32)
+        result = numpy_linear_eq_func(x)
+        assert isinstance(result, np.ndarray)
+
+    def test_scalar_matches_jax(self, linear_eq_func, numpy_linear_eq_func):
+        """Scalar evaluation must agree with JaxEqFunc."""
+        x = 300.0
+        np.testing.assert_allclose(
+            numpy_linear_eq_func(x), float(linear_eq_func(x)), rtol=1e-5
+        )
+
+    def test_1d_array_matches_jax(self, linear_eq_func, numpy_linear_eq_func):
+        """1-D array evaluation must agree with JaxEqFunc."""
+        x = np.linspace(50.0, 3000.0, 50, dtype=np.float32)
+        np.testing.assert_allclose(
+            numpy_linear_eq_func(x), np.array(linear_eq_func(x)), rtol=1e-5
+        )
+
+    def test_2d_array_matches_jax(self, linear_eq_func, numpy_linear_eq_func):
+        """2-D array evaluation must agree with JaxEqFunc.
+
+        This is critical: invert_numpy calls f_eq on the entire 2-D image at
+        once, so NumpyEqFunc must handle arbitrary shapes (np.interp does).
+        """
+        rng = np.random.default_rng(3)
+        x = rng.uniform(50.0, 3000.0, (10, 50)).astype(np.float32)
+        np.testing.assert_allclose(
+            numpy_linear_eq_func(x), np.array(linear_eq_func(x)), rtol=1e-5
+        )
+
+    def test_clipping_below_xmin_matches_jax(
+        self, linear_eq_func, numpy_linear_eq_func
+    ):
+        """Values below x_grid[0] must be clipped, matching JaxEqFunc."""
+        x = np.array([-500.0], dtype=np.float32)
+        np.testing.assert_allclose(
+            numpy_linear_eq_func(x), np.array(linear_eq_func(x)), rtol=1e-5
+        )
+
+    def test_clipping_above_xmax_matches_jax(
+        self, linear_eq_func, numpy_linear_eq_func
+    ):
+        """Values above x_max (peak of y_grid) must be clipped, matching JaxEqFunc."""
+        x = np.array([99999.0], dtype=np.float32)
+        np.testing.assert_allclose(
+            numpy_linear_eq_func(x), np.array(linear_eq_func(x)), rtol=1e-5
+        )
+
+    def test_realistic_1d_matches_jax(self, realistic_eq_func, numpy_realistic_eq_func):
+        """Agreement for the realistic (log-saturating) curve on a 1-D array."""
+        x = np.geomspace(15.0, 4000.0, 60, dtype=np.float32)
+        np.testing.assert_allclose(
+            numpy_realistic_eq_func(x), np.array(realistic_eq_func(x)), rtol=1e-5
+        )
+
+    def test_realistic_2d_matches_jax(self, realistic_eq_func, numpy_realistic_eq_func):
+        """Agreement for the realistic curve on a 2-D array."""
+        rng = np.random.default_rng(4)
+        x = rng.uniform(15.0, 4000.0, (8, 40)).astype(np.float32)
+        np.testing.assert_allclose(
+            numpy_realistic_eq_func(x), np.array(realistic_eq_func(x)), rtol=1e-5
+        )
+
+
+class TestInvertNumpy:
+    """invert_numpy must reproduce the JAX invert results exactly."""
+
+    @pytest.fixture
+    def numpy_realistic_eq_func(self, realistic_eq_func):
+        from ztfsensors.pocket.models.base import NumpyEqFunc
+
+        return NumpyEqFunc(
+            x_grid=np.array(realistic_eq_func.x_grid),
+            y_grid=np.array(realistic_eq_func.y_grid),
+        )
+
+    @pytest.fixture
+    def numpy_linear_eq_func(self, linear_eq_func):
+        from ztfsensors.pocket.models.base import NumpyEqFunc
+
+        return NumpyEqFunc(
+            x_grid=np.array(linear_eq_func.x_grid),
+            y_grid=np.array(linear_eq_func.y_grid),
+        )
+
+    def test_output_shape(self, numpy_realistic_eq_func, realistic_image):
+        """Output must have the same shape as the input."""
+        from ztfsensors.pocket.pix_distortion import invert_numpy
+
+        result = invert_numpy(realistic_image, numpy_realistic_eq_func)
+        assert result.shape == realistic_image.shape
+
+    def test_returns_numpy_array(self, numpy_realistic_eq_func, realistic_image):
+        """invert_numpy must return a plain numpy array."""
+        from ztfsensors.pocket.pix_distortion import invert_numpy
+
+        result = invert_numpy(realistic_image, numpy_realistic_eq_func)
+        assert isinstance(result, np.ndarray)
+
+    def test_zero_image_gives_zero_output(self, numpy_linear_eq_func):
+        """All-zero image → all-zero output (f_eq(0) = 0 for linear_eq_func)."""
+        from ztfsensors.pocket.pix_distortion import invert_numpy
+
+        d = np.zeros((5, 50), dtype=np.float32)
+        result = invert_numpy(d, numpy_linear_eq_func)
+        np.testing.assert_allclose(result, 0.0, atol=1e-6)
+
+    def test_matches_jax_on_flat_image(
+        self, numpy_realistic_eq_func, realistic_eq_func, flat_row
+    ):
+        """invert_numpy and JAX invert agree on a tiled flat-sky image."""
+        from ztfsensors.pocket.pix_distortion import invert_numpy
+
+        d = np.tile(flat_row, (5, 1))
+        result_np = invert_numpy(d, numpy_realistic_eq_func)
+        result_jax = np.array(invert(jnp.array(d), realistic_eq_func))
+        np.testing.assert_allclose(result_np, result_jax, rtol=1e-5)
+
+    def test_matches_jax_on_realistic_image(
+        self, numpy_realistic_eq_func, realistic_eq_func, realistic_image
+    ):
+        """invert_numpy and JAX invert agree on a realistic 2-D image."""
+        from ztfsensors.pocket.pix_distortion import invert_numpy
+
+        result_np = invert_numpy(realistic_image, numpy_realistic_eq_func)
+        result_jax = np.array(invert(jnp.array(realistic_image), realistic_eq_func))
+        np.testing.assert_allclose(result_np, result_jax, rtol=1e-5)
+
+    def test_matches_jax_row_by_row(
+        self, numpy_realistic_eq_func, realistic_eq_func, realistic_image
+    ):
+        """Each row of invert_numpy matches the corresponding JAX invert_line."""
+        from ztfsensors.pocket.pix_distortion import invert_numpy
+
+        result_np = invert_numpy(realistic_image, numpy_realistic_eq_func)
+        for i in range(realistic_image.shape[0]):
+            result_jax_row = np.array(
+                invert_line(jnp.array(realistic_image[i]), realistic_eq_func)
+            )
+            np.testing.assert_allclose(
+                result_np[i],
+                result_jax_row,
+                rtol=1e-5,
+                err_msg=f"Row {i} mismatch between invert_numpy and JAX invert_line",
+            )
+
+    def test_roundtrip_with_jax_distort(
+        self, numpy_realistic_eq_func, realistic_eq_func, realistic_image
+    ):
+        """invert_numpy undoes distortion produced by JAX predict."""
+        from ztfsensors.pocket.pix_distortion import invert_numpy
+
+        true_vals = jnp.array(realistic_image)
+        distorted_jax = predict(true_vals, realistic_eq_func)
+        distorted_np = np.array(distorted_jax)
+
+        recovered = invert_numpy(distorted_np, numpy_realistic_eq_func)
+        np.testing.assert_allclose(recovered, realistic_image, atol=0.5)
+
+
+class TestCorrectPixels:
+    """correct_pixels must dispatch to JAX or numpy based on the type of f_eq."""
+
+    @pytest.fixture
+    def numpy_realistic_eq_func(self, realistic_eq_func):
+        from ztfsensors.pocket.models.base import NumpyEqFunc
+
+        return NumpyEqFunc(
+            x_grid=np.array(realistic_eq_func.x_grid),
+            y_grid=np.array(realistic_eq_func.y_grid),
+        )
+
+    def test_jax_dispatch_returns_result(self, realistic_eq_func, realistic_image):
+        """With a JaxEqFunc, correct_pixels returns a result of the right shape."""
+        from ztfsensors.pocket import correct_pixels
+
+        result = correct_pixels(jnp.array(realistic_image), realistic_eq_func)
+        assert result.shape == realistic_image.shape
+
+    def test_numpy_dispatch_returns_numpy_array(
+        self, numpy_realistic_eq_func, realistic_image
+    ):
+        """With a NumpyEqFunc, correct_pixels must return a plain numpy array."""
+        from ztfsensors.pocket import correct_pixels
+
+        result = correct_pixels(realistic_image, numpy_realistic_eq_func)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == realistic_image.shape
+
+    def test_numpy_and_jax_dispatch_agree(
+        self, numpy_realistic_eq_func, realistic_eq_func, realistic_image
+    ):
+        """Both dispatch paths must produce the same numerical result."""
+        from ztfsensors.pocket import correct_pixels
+
+        result_jax = np.array(
+            correct_pixels(jnp.array(realistic_image), realistic_eq_func)
+        )
+        result_np = correct_pixels(realistic_image, numpy_realistic_eq_func)
+        np.testing.assert_allclose(result_np, result_jax, rtol=1e-5)
+
+
+class TestMakeEqFuncBackend:
+    """BaseEquilibriumModel.make_eq_func must accept a backend= kwarg."""
+
+    @pytest.fixture
+    def poly_model(self):
+        from ztfsensors.pocket.models.poly_temp_eq_model import PolyTempEqModel
+
+        return PolyTempEqModel(
+            p_deg=[2, 2],
+            q_deg=[2],
+            x_knot=200.0,
+            temp_ref=160.0,
+            temp_scale=5.0,
+        )
+
+    @pytest.fixture
+    def poly_params(self, poly_model):
+        rng = np.random.default_rng(99)
+        return rng.normal(0, 0.1, poly_model.params_shape)
+
+    def test_jax_backend_returns_jax_eq_func(self, poly_model, poly_params):
+        """make_eq_func(backend='jax') must return a JaxEqFunc."""
+        eq_func = poly_model.make_eq_func(poly_params, ccd_temp=160.0, backend="jax")
+        assert isinstance(eq_func, JaxEqFunc)
+
+    def test_numpy_backend_returns_numpy_eq_func(self, poly_model, poly_params):
+        """make_eq_func(backend='numpy') must return a NumpyEqFunc."""
+        from ztfsensors.pocket.models.base import NumpyEqFunc
+
+        eq_func = poly_model.make_eq_func(poly_params, ccd_temp=160.0, backend="numpy")
+        assert isinstance(eq_func, NumpyEqFunc)
+
+    def test_numpy_and_jax_backends_agree(self, poly_model, poly_params):
+        """JaxEqFunc and NumpyEqFunc from make_eq_func must evaluate identically."""
+        grid = np.geomspace(50.0, 5000.0, 50)
+        eq_jax = poly_model.make_eq_func(
+            poly_params, ccd_temp=160.0, backend="jax", tabulation_grid=grid
+        )
+        eq_np = poly_model.make_eq_func(
+            poly_params, ccd_temp=160.0, backend="numpy", tabulation_grid=grid
+        )
+        x = np.linspace(60.0, 4000.0, 40, dtype=np.float32)
+        np.testing.assert_allclose(eq_np(x), np.array(eq_jax(x)), rtol=1e-5)
+
+    def test_invalid_backend_raises_value_error(self, poly_model, poly_params):
+        """Unknown backend name must raise ValueError."""
+        with pytest.raises(ValueError, match="backend"):
+            poly_model.make_eq_func(poly_params, ccd_temp=160.0, backend="torch")
+
+
+class TestDbGetEqFuncBackend:
+    """EqFuncDb.get_eq_func must accept and forward a backend= kwarg."""
+
+    @pytest.fixture
+    def poly_db(self):
+        """A minimal in-memory EqFuncDb backed by a PolyTempEqModel."""
+        import polars as pl
+
+        from ztfsensors.pocket.db import EqFuncDb
+        from ztfsensors.pocket.models.poly_temp_eq_model import PolyTempEqModel
+
+        model = PolyTempEqModel(
+            p_deg=[2, 2],
+            q_deg=[2],
+            x_knot=200.0,
+            temp_ref=160.0,
+            temp_scale=5.0,
+        )
+        rng = np.random.default_rng(77)
+        params = rng.normal(0, 0.1, model.params_shape).tolist()
+        df = pl.DataFrame(
+            {
+                "ccdid": [1],
+                "qid": [1],
+                "mjd_start": [58000.0],
+                "mjd_end": [59000.0],
+                "temp_min": [155.0],
+                "temp_max": [165.0],
+                "params": [params],
+            }
+        )
+        return EqFuncDb(df=df, model=model)
+
+    @pytest.fixture
+    def tabulation_grid(self):
+        return np.geomspace(50.0, 5000.0, 50)
+
+    def test_jax_backend_returns_jax_eq_func(self, poly_db, tabulation_grid):
+        """get_eq_func(backend='jax') must return a JaxEqFunc."""
+        eq_func = poly_db.get_eq_func(
+            ccdid=1,
+            qid=1,
+            mjd=58050.0,
+            ccd_temp=160.0,
+            tabulation_grid=tabulation_grid,
+            backend="jax",
+        )
+        assert isinstance(eq_func, JaxEqFunc)
+
+    def test_numpy_backend_returns_numpy_eq_func(self, poly_db, tabulation_grid):
+        """get_eq_func(backend='numpy') must return a NumpyEqFunc."""
+        from ztfsensors.pocket.models.base import NumpyEqFunc
+
+        eq_func = poly_db.get_eq_func(
+            ccdid=1,
+            qid=1,
+            mjd=58050.0,
+            ccd_temp=160.0,
+            tabulation_grid=tabulation_grid,
+            backend="numpy",
+        )
+        assert isinstance(eq_func, NumpyEqFunc)
+
+    def test_numpy_and_jax_backends_agree(self, poly_db, tabulation_grid):
+        """Both backends must evaluate identically on the same tabulation grid."""
+        eq_jax = poly_db.get_eq_func(
+            ccdid=1,
+            qid=1,
+            mjd=58050.0,
+            ccd_temp=160.0,
+            tabulation_grid=tabulation_grid,
+            backend="jax",
+        )
+        eq_np = poly_db.get_eq_func(
+            ccdid=1,
+            qid=1,
+            mjd=58050.0,
+            ccd_temp=160.0,
+            tabulation_grid=tabulation_grid,
+            backend="numpy",
+        )
+        x = np.linspace(60.0, 4000.0, 40, dtype=np.float32)
+        np.testing.assert_allclose(eq_np(x), np.array(eq_jax(x)), rtol=1e-5)
+
+    def test_invalid_backend_raises(self, poly_db, tabulation_grid):
+        """Unknown backend must propagate a ValueError from make_eq_func."""
+        with pytest.raises(ValueError, match="backend"):
+            poly_db.get_eq_func(
+                ccdid=1,
+                qid=1,
+                mjd=58050.0,
+                ccd_temp=160.0,
+                tabulation_grid=tabulation_grid,
+                backend="cupy",
+            )

--- a/ztfsensors/pocket/__init__.py
+++ b/ztfsensors/pocket/__init__.py
@@ -2,11 +2,36 @@ from pathlib import Path
 
 from .db import EqFuncDb
 from .fit import FitDiagnostics, FitRecord, FitResults, fit_eq_model
-from .pix_distortion import invert, plot_1d, plot_2d, predict
+from .models.base import JaxEqFunc, NumpyEqFunc
+from .pix_distortion import invert, invert_numpy, plot_1d, plot_2d, predict
 
-# the correction function is called "correct_pixels" in ztfimg
-# better stick to that name
-correct_pixels = invert
+
+def correct_pixels(distorted_pixvals, f_eq):
+    """Invert the pocket effect on a full 2-D image.
+
+    Dispatches to the numpy or JAX backend based on the type of *f_eq*:
+
+    * :class:`~ztfsensors.pocket.models.base.NumpyEqFunc` → :func:`~ztfsensors.pocket.pix_distortion.invert_numpy` (no JAX at call time)
+    * :class:`~ztfsensors.pocket.models.base.JaxEqFunc`   → :func:`~ztfsensors.pocket.pix_distortion.invert`       (JAX vmap/scan)
+
+    Parameters
+    ----------
+    distorted_pixvals : array_like, shape (nrows, ncols)
+        2-D image with pocket-effect distortion.
+    f_eq : NumpyEqFunc or JaxEqFunc
+        Equilibrium function, as returned by
+        :meth:`~ztfsensors.pocket.db.EqFuncDb.get_eq_func`.
+
+    Returns
+    -------
+    np.ndarray or jax.Array, shape (nrows, ncols)
+        Corrected pixel values.
+    """
+    from .models.base import NumpyEqFunc
+
+    if isinstance(f_eq, NumpyEqFunc):
+        return invert_numpy(distorted_pixvals, f_eq)
+    return invert(distorted_pixvals, f_eq)
 
 
 def load_db(prefix: "str | Path | None" = None) -> EqFuncDb:
@@ -50,8 +75,12 @@ __all__ = [
     "FitResults",
     "FitDiagnostics",
     # Pixel distortion utilities
+    "correct_pixels",
     "invert",
+    "invert_numpy",
     "plot_1d",
     "plot_2d",
     "predict",
+    # Equilibrium function types
+    "NumpyEqFunc",
 ]

--- a/ztfsensors/pocket/db.py
+++ b/ztfsensors/pocket/db.py
@@ -4,15 +4,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-# Directory that ships with the package and holds the bundled eq_db files.
-_BUNDLED_DATA_DIR = Path(__file__).parent / "data"
-_BUNDLED_DB_PREFIX = _BUNDLED_DATA_DIR / "eq_db"
-
 import numpy as np
 import polars as pl
 import yaml
 
-from .models.base import BaseEquilibriumModel, JaxEqFunc
+from .models.base import BaseEquilibriumModel
+
+# Directory that ships with the package and holds the bundled eq_db files.
+_BUNDLED_DATA_DIR = Path(__file__).parent / "data"
+_BUNDLED_DB_PREFIX = _BUNDLED_DATA_DIR / "eq_db"
 
 
 def _model_from_header(header: dict) -> BaseEquilibriumModel:
@@ -323,9 +323,10 @@ class EqFuncDb:
         mjd: float,
         ccd_temp: float,
         tabulation_grid=None,
-    ) -> JaxEqFunc:
+        backend: str = "numpy",
+    ):
         """
-        Create a JIT-compiled equilibrium function for specific observation conditions.
+        Create an equilibrium function for specific observation conditions.
 
         Retrieves the appropriate parameters and instantiates a fast equilibrium
         function at the given CCD temperature.
@@ -343,11 +344,15 @@ class EqFuncDb:
         tabulation_grid : array_like, optional
             Grid of x values for tabulating the function. If None, uses the
             model's default grid.
+        backend : str, optional
+            Passed through to :meth:`BaseEquilibriumModel.make_eq_func`.
+            ``'numpy'`` (default) returns a :class:`NumpyEqFunc`;
+            ``'jax'`` returns a :class:`JaxEqFunc`.
 
         Returns
         -------
-        JaxEqFunc
-            JIT-compiled equilibrium function ready for fast evaluation.
+        NumpyEqFunc or JaxEqFunc
+            Equilibrium function ready for fast evaluation.
 
         Raises
         ------
@@ -361,6 +366,7 @@ class EqFuncDb:
             params=params,
             ccd_temp=ccd_temp,
             tabulation_grid=tabulation_grid,
+            backend=backend,
         )
 
     # ------------------------------------------------------------------

--- a/ztfsensors/pocket/fit.py
+++ b/ztfsensors/pocket/fit.py
@@ -778,7 +778,7 @@ def fit_eq_model(
         # We better perform a robust fit here.
         H = J.T @ J
         rhs = J.T @ yy
-        fact = cholmod.cholesky(H, beta=beta)
+        fact = cholmod.cholesky(H.tocsc(), beta=beta)
         params = fact(rhs)
     else:
         J = J.tocoo()

--- a/ztfsensors/pocket/models/base.py
+++ b/ztfsensors/pocket/models/base.py
@@ -117,7 +117,9 @@ class NumpyEqFunc:
         """
         x_arr = np.asarray(x, dtype=np.float32)
         x_clipped = np.clip(x_arr, self.x_grid[0], self.x_max)
-        return np.interp(x_clipped, self.x_grid, self.y_grid)
+        # np.interp always returns float64 regardless of input dtypes; cast back
+        # to float32 to match JaxEqFunc's behaviour and keep invert_numpy in f32.
+        return np.interp(x_clipped, self.x_grid, self.y_grid).astype(np.float32)
 
 
 class BaseEquilibriumModel(ABC):

--- a/ztfsensors/pocket/models/base.py
+++ b/ztfsensors/pocket/models/base.py
@@ -79,6 +79,47 @@ class JaxEqFunc(eqx.Module):
         return jnp.interp(x_clipped, self.x_grid, self.y_grid)
 
 
+class NumpyEqFunc:
+    """Pure-numpy equilibrium function via linear interpolation on a tabulated grid.
+
+    Drop-in replacement for :class:`JaxEqFunc` for the inference path.
+    No JAX dependency at call time.
+
+    Attributes
+    ----------
+    x_grid : np.ndarray
+        Grid of x values (sky levels) for tabulation.
+    y_grid : np.ndarray
+        Corresponding y values (overscan signal) at each grid point.
+    x_max : float
+        x value at the maximum of y_grid (used for clipping, same as JaxEqFunc).
+    """
+
+    def __init__(self, x_grid, y_grid):
+        self.x_grid = np.asarray(x_grid, dtype=np.float32)
+        self.y_grid = np.asarray(y_grid, dtype=np.float32)
+        self.x_max = self.x_grid[np.argmax(self.y_grid)]
+
+    def __call__(self, x):
+        """Evaluate the equilibrium function at x (any shape).
+
+        Values beyond x_max are clipped identically to JaxEqFunc.
+
+        Parameters
+        ----------
+        x : array_like
+            Sky level value(s).  np.interp handles any shape natively.
+
+        Returns
+        -------
+        np.ndarray
+            Interpolated overscan signal value(s), same shape as x.
+        """
+        x_arr = np.asarray(x, dtype=np.float32)
+        x_clipped = np.clip(x_arr, self.x_grid[0], self.x_max)
+        return np.interp(x_clipped, self.x_grid, self.y_grid)
+
+
 class BaseEquilibriumModel(ABC):
     """
     Abstract base class for equilibrium models.
@@ -404,9 +445,11 @@ class BaseEquilibriumModel(ABC):
 
         return np.geomspace(xmin, xmax, n)
 
-    def make_eq_func(self, params, ccd_temp: float, tabulation_grid=None):
+    def make_eq_func(
+        self, params, ccd_temp: float, tabulation_grid=None, backend: str = "numpy"
+    ):
         """
-        Create a JIT-compiled equilibrium function at a specific temperature.
+        Create an equilibrium function at a specific temperature.
 
         Tabulates the model on a grid and returns a fast interpolating function.
 
@@ -418,11 +461,15 @@ class BaseEquilibriumModel(ABC):
             CCD temperature at which to evaluate the function.
         tabulation_grid : array_like, optional
             Grid of x values for tabulation. If None, uses default_tabulation_grid().
+        backend : str, optional
+            Which backend to use for the returned callable.
+            ``'numpy'`` (default) returns a :class:`NumpyEqFunc` (no JAX at call time).
+            ``'jax'`` returns a :class:`JaxEqFunc` (JIT-compiled via equinox).
 
         Returns
         -------
-        JaxEqFunc
-            JIT-compiled equilibrium function ready for evaluation.
+        NumpyEqFunc or JaxEqFunc
+            Equilibrium function ready for evaluation.
 
         Raises
         ------
@@ -438,7 +485,12 @@ class BaseEquilibriumModel(ABC):
 
         y_grid = self.evaluate(x=tabulation_grid, ccd_temp=ccd_temp, params=params)
 
-        return JaxEqFunc(
-            x_grid=jnp.asarray(tabulation_grid, dtype=jnp.float32),
-            y_grid=jnp.asarray(y_grid, dtype=jnp.float32),
-        )
+        if backend == "numpy":
+            return NumpyEqFunc(x_grid=tabulation_grid, y_grid=y_grid)
+        elif backend == "jax":
+            return JaxEqFunc(
+                x_grid=jnp.asarray(tabulation_grid, dtype=jnp.float32),
+                y_grid=jnp.asarray(y_grid, dtype=jnp.float32),
+            )
+        else:
+            raise ValueError(f"Unknown backend {backend!r}: expected 'numpy' or 'jax'.")

--- a/ztfsensors/pocket/pix_distortion.py
+++ b/ztfsensors/pocket/pix_distortion.py
@@ -1,9 +1,7 @@
-from configparser import Interpolation
-
 import jax
 import jax.numpy as jnp
+import numpy as np
 from astropy.visualization import ZScaleInterval
-from jax import lax
 
 
 def solve_delta(N_i, T_prev, f_eq, n_iter=3):
@@ -75,6 +73,46 @@ def invert(distorted_pixvals, f_eq):
     Invert the distortion on a full 2D image
     """
     return jax.vmap(invert_line, in_axes=(0, None), out_axes=0)(distorted_pixvals, f_eq)
+
+
+def invert_numpy(distorted_pixvals, f_eq):
+    """Invert the pocket effect on a 2-D image using pure numpy.
+
+    This is the numpy equivalent of :func:`invert`.  It produces the same
+    numerical result without requiring JAX at call time.
+
+    Mathematical note
+    -----------------
+    Inside :func:`invert_line` the ``lax.scan`` state update is::
+
+        T_new[i] = f_eq(d[i])          # no dependence on T_prev
+        delta[i] = T_new[i] - T_prev   # = f_eq(d[i]) - f_eq(d[i-1])
+
+    Because ``T_new[i]`` is independent of the scan carry, the entire scan
+    collapses to a vectorised ``diff``::
+
+        feq   = f_eq(d)                          # apply f_eq to whole image
+        delta = concat([feq[:, :1], diff(feq)])  # leading zero carried → f_eq(d[0])
+        out   = d + delta
+
+    Parameters
+    ----------
+    distorted_pixvals : array_like, shape (nrows, ncols)
+        2-D image with pocket-effect distortion (data + overscan columns).
+        Expected to be in "read" order (amplifier at column 0).
+    f_eq : callable
+        Equilibrium function.  Must accept a 2-D numpy array and return a
+        same-shaped array (e.g. :class:`~ztfsensors.pocket.models.base.NumpyEqFunc`).
+
+    Returns
+    -------
+    np.ndarray, shape (nrows, ncols)
+        Corrected pixel values.
+    """
+    d = np.asarray(distorted_pixvals, dtype=np.float32)
+    feq_vals = f_eq(d)  # shape (nrows, ncols); np.interp handles nD arrays
+    deltas = np.concatenate([feq_vals[:, :1], np.diff(feq_vals, axis=1)], axis=1)
+    return d + deltas
 
 
 def plot_1d(


### PR DESCRIPTION
Implement a new pure-numpy backend for pocket effect correction. The backend can be choosen on `db.get_eq_func` (numpy or jax, default to numpy). New tests added to ensure parity of the numpy and jax backends.